### PR TITLE
Release 2015-11-03

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,7 +57,7 @@ class ApplicationController < ActionController::Base
       discussions = search_db(:disc, query, 24)[:results]
     end
 
-    @results = {:all => [design_methods, case_studies, discussions].flatten.shuffle[0..24],
+    @results = {:all => [design_methods, case_studies, discussions].flatten,
       :dm => design_methods, :cs => case_studies, :disc => discussions}
 
     design_method_names = design_methods.map { |design_method| design_method.name }

--- a/app/views/application/search.html.haml
+++ b/app/views/application/search.html.haml
@@ -20,6 +20,9 @@
   .padding{
     padding-top: 15px;
   }
+  .nav-tabs{
+    cursor: pointer;
+  }
 / TOP BAR
 .row
   .col-md-2

--- a/app/views/application/search.html.haml
+++ b/app/views/application/search.html.haml
@@ -1,21 +1,21 @@
-:javascript
-  $(function(){
-    // $('.tab-pane[data-link ="'+ "all" +'"]').show().siblings(".tab-pane").hide();
-    $('.sidebar[data-link ="'+ "all" +'"]').show().siblings(".sidebar").hide();
-    $('#tabs li a').click(function(e){
-      e.preventDefault();
-      // Alternate tabs
-      $(this).parent()
-             .addClass('active')
-             .siblings()
-             .removeClass('active');
-      var link = $(this).data('link');
+/ :javascript
+/   $(function(){
+/     // $('.tab-pane[data-link ="'+ "all" +'"]').show().siblings(".tab-pane").hide();
+/     $('.sidebar[data-link ="'+ "all" +'"]').show().siblings(".sidebar").hide();
+/     $('#tabs li a').click(function(e){
+/       e.preventDefault();
+/       // Alternate tabs
+/       $(this).parent()
+/              .addClass('active')
+/              .siblings()
+/              .removeClass('active');
+/       var link = $(this).data('link');
   
-      // $('.tab-pane[data-link ~="'+ link +'"]').hide();
-      $('.tab-pane[data-link ="'+ link +'"]').show().siblings(".tab-pane").hide();
-      $('.sidebar[data-link ="'+ link +'"]').show().siblings(".sidebar").hide();
-    })
-  });
+/       // $('.tab-pane[data-link ~="'+ link +'"]').hide();
+/       $('.tab-pane[data-link ="'+ link +'"]').show().siblings(".tab-pane").hide();
+/       $('.sidebar[data-link ="'+ link +'"]').show().siblings(".sidebar").hide();
+/     })
+/   });
 :css
   .padding{
     padding-top: 15px;
@@ -50,7 +50,7 @@
       / SIDEBAR FOR DISCUSSION
   / All Search Tab
   .tab-pane.col-sm-10.padding{"data-link" => "all"}
-    - @results[:dm].each do |method|
+    - @results[:all].each do |method|
       = render "/layouts/thumbnail", locals: @thumb_obj = thumbnail(method,"3")
   / Method Search Tab
   .tab-pane.col-sm-10.padding{"data-link" => "dm"}


### PR DESCRIPTION
Hi DX, we have an awesome release coming up. Also, it's in a really neat visual format!!

Check these nice bugfixes and improvements from the past few weeks:

### 1. Editing descriptions just got a whole lot easier

| Before | After |
| --- | --- |
| Markdown source had to be edited directly. | The editor is still plain, but now there is a rich text toolbar and a live Markdown preview! |
| <img width="676" alt="screen shot 2015-10-26 at 10 46 27 am" src="https://cloud.githubusercontent.com/assets/1570168/10737902/017cebe8-7bd2-11e5-84d7-47d1fc0973c8.png"> | <img width="695" alt="screen shot 2015-10-26 at 11 09 07 am" src="https://cloud.githubusercontent.com/assets/1570168/10737907/046768ce-7bd2-11e5-8825-a7a6f1ae2fea.png"> |

[**DEMO**](https://thedesignexchange-staging.herokuapp.com/design_methods/4/edit) (requires login) &middot; Thanks @selenashang for #95!

### 2. Fixed the sizes of the cards on narrower viewports

| Before | After |
| --- | --- |
| Cards sometimes became wider when the screen became narrower. | Cards take on more sensible widths. |
| <img width="957" alt="screen shot 2015-10-26 at 10 04 41 am" src="https://cloud.githubusercontent.com/assets/1570168/10736249/2776c91c-7bc9-11e5-99d0-a134cc3ee4b5.png"> | <img width="957" alt="screen shot 2015-10-26 at 10 04 35 am" src="https://cloud.githubusercontent.com/assets/1570168/10736251/2947b922-7bc9-11e5-96dd-fa8204fca13c.png"> |

[**DEMO**](https://thedesignexchange-staging.herokuapp.com/design_methods) &middot; Thanks @charleszwang for #100!

### 3. Fixed issue with sidebar doubling up
| Before | After |
| --- | --- |
| Sidebar doubles up after searching | Sidebar looks normal |
| ![screen shot 2015-10-27 at 5 44 27 pm](https://cloud.githubusercontent.com/assets/9519179/10776858/b376ac8e-7cd2-11e5-9210-895a5ca1718d.png) | ![screen shot 2015-10-27 at 5 48 40 pm](https://cloud.githubusercontent.com/assets/9519179/10776898/ff711afc-7cd2-11e5-9488-02dca2e809f9.png) |

[**DEMO**](https://thedesignexchange-staging.herokuapp.com/design_methods/search/a) &middot; Thanks @syjkim35 for #97! More deets: #107

### 4. Tabs on search results page are now accessible
| Before | After |
| --- | --- |
| Can't click on Methods and Case Studies tabs | All 3 tabs are clickable |
| ![before](https://cloud.githubusercontent.com/assets/8680536/10803065/ae976b8a-7d7d-11e5-8c1d-9187d319484d.png) | ![after](https://cloud.githubusercontent.com/assets/8680536/10805975/317782c2-7d8f-11e5-9023-8e883665fae1.png) |

[**DEMO**](https://thedesignexchange-staging.herokuapp.com/design_methods/search/user) &middot; Thanks @jennyfromtheweb and @szhu for #87! More deets: #107

### 5. Methods in New Case Studies now sorted alphabetically

| Before | After |
| --- | --- |
| Methods sorted by ID. These are alphabetical, but ones later in the list are not. | Methods sorted alphabetically. Note that the first one listed here isn't visible at the top of the "before" list. |
| ![screen shot 2015-10-29 at 8 01 40 pm](https://cloud.githubusercontent.com/assets/7282272/10837586/6fb017c2-7e78-11e5-96a1-e381269848ce.png)  | ![screen shot 2015-10-29 at 8 01 10 pm](https://cloud.githubusercontent.com/assets/7282272/10837602/a584d338-7e78-11e5-9129-a5627330a3f7.png) | 

[**DEMO**](http://localhost:3000/case_studies/new) &middot; Thanks @szhu and @selenashang for #67!


---

That's all for this week folks, till next time!

cc @TheDesignExchange/release-watchers 