### PR TITLE
Responsive feature

### DIFF
--- a/app/assets/stylesheets/_deheader.css.scss
+++ b/app/assets/stylesheets/_deheader.css.scss
@@ -13,9 +13,8 @@
   font-size:150%;
   color: white;
   line-height: normal;
-  margin-top: 16px;
   display: table;
-  margin: 16px auto;
+  margin: 24px auto;
 }
 
 .h1 {
@@ -85,19 +84,34 @@
 }
 
 @media (max-width: 768px) {
+  .login-margin {
+    margin: 5% 0 0 0;
+  }
+
   .jumbotron {
-    height: 800px;
+    height: 600px;
+    .container {
+      margin: 0;
+      padding: 0;
+    }
   }
 
   .header-img {
-    padding-top: 100px;
+    padding-top: 20px;
     img {
       width: 100%;
     }
-    margin: 0 -30px 0 -30px;
   }
 
   .boxed {
     width: 100%;
+    padding: 15px;
+    h2 {
+      font-size:150%;
+      margin-bottom: 0px;
+    }
+    p {
+      font-size: 90%;
+    }
   }
 }

--- a/app/assets/stylesheets/_deheader.css.scss
+++ b/app/assets/stylesheets/_deheader.css.scss
@@ -1,0 +1,103 @@
+@import url(//fonts.googleapis.com/css?family=Arvo:700);
+
+.header-img {
+  padding-top: 100px;
+  img {
+    width: 600px;
+  }
+}
+
+.join {
+  font-family: 'Work Sans', sans-serif;
+  height:50px;
+  font-size:150%;
+  color: white;
+  line-height: normal;
+  margin-top: 16px;
+  display: table;
+  margin: 16px auto;
+}
+
+.h1 {
+  font-size: 300%;
+}
+.jumbotron {
+  font-size: 17px;
+  background: rgb(89, 88, 91);
+  color: white;
+  height:420px;
+  padding-top: 20px;
+}
+
+.subtitle {
+  font-size: 20px;
+  margin-top:2%;
+}
+
+.login-margin {
+  margin-left: 25%;
+  margin-right: 25%;
+  margin-top: 5%;
+}
+
+.btn.sharp {
+  border-radius:0;
+  letter-spacing: 2px;
+  padding: 10px 50px;
+}
+.logo{
+  width: 300px;
+}
+.header {
+  padding: 25px 10px;
+  height: 55px;
+  border-bottom: 1px solid #d3d3d3;
+  overflow: no-content;
+  min-width: 400px;
+}
+#header-right {
+  width: 50%;
+  border-color: blue;
+}
+.btn-xl {
+  padding: 18px 28px;
+  font-size: 22px;
+  border-radius: 10px;
+}
+
+.boxed {
+  border: 2px solid #009966;
+  width: 350px;
+  margin: auto;
+  padding: 25px;
+  border-radius: 20px;
+
+  h2 {
+    font-family: 'Work Sans', sans-serif;
+    font-size:165%;
+    margin-top: 0;
+  }
+
+  p {
+    font-size:100%;
+    font-family: 'Source Sans Pro', sans-serif;
+  }
+}
+
+@media (max-width: 768px) {
+  .jumbotron {
+    height: 800px;
+  }
+
+  .header-img {
+    padding-top: 100px;
+    img {
+      width: 100%;
+    }
+    margin: 0 -30px 0 -30px;
+  }
+
+  .boxed {
+    width: 100%;
+  }
+}

--- a/app/assets/stylesheets/_landing.css.scss
+++ b/app/assets/stylesheets/_landing.css.scss
@@ -1,0 +1,66 @@
+@import url(//fonts.googleapis.com/css?family=Arvo:700);
+
+#showcase {
+  .row {
+    margin-bottom: 10%;
+  }
+
+  .subtitle {
+    text-align:center;
+    font-size:100%;
+    font-family: 'Source Sans Pro', sans-serif;
+  }
+
+  h1 {
+    text-align:center;
+    font-family: 'Work Sans', sans-serif;
+  }
+
+  h2 {
+    margin-bottom:10%;
+    font-family: 'Work Sans', sans-serif;
+    color: white
+  }
+
+  h4 {
+    font-size:100%;
+    color: white;
+    margin-top:-10%;
+  }
+}
+
+  .layer1 {
+    background-color: rgba(134, 198, 124, 0.92);
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 25%;
+    margin-top: 20.1%
+  }
+
+  .left-padding{
+    padding-left: 10px
+  }
+
+  #method-background {
+    background-image: image-url("MethodLandingPage.jpg");
+    background-size: contain;
+    background-repeat: no-repeat;
+    width: 100%;
+    height: 0;
+    margin-bottom: 28px;
+    padding-top: 68.44%; /* (img-height / img-width * container-width) */
+                /* (438 / 640) */
+    .layer {
+      background-color: rgba(134, 198, 124, 0.85);
+      width: 100%;
+      margin-top: -68.44%;
+      padding: 10px;
+    }
+  }
+
+  .col-sm-6 {
+    h1 {
+      margin-bottom: 0;
+    }
+  }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -21,6 +21,14 @@
  *= require jquery.tablesorter.pager
  */
 
+#search {
+   background-color: #f8f8f8;
+}
+
+.notice {
+  margin-top:50px;
+}
+
 @media (max-width: 768px) {
   #search{
     height: 60px;
@@ -34,12 +42,10 @@
       width: 100%;
     }
   }
+  .notice {
+    margin-top: 126px;
+  }
 }
-
-#search {
-   background-color: #f8f8f8;
-}
-
 
  /* OVERRIDE BOOTSTRAP ANCHOR BEHAVIOR */
  a {
@@ -263,6 +269,22 @@ img.logo{
     }
     .card .likes{
       font-size: 10pt;
+    }
+
+    @media (max-width: 768px) {
+      .card {
+        height: 150px;
+        margin: 10px 0 10px 0;
+      }
+
+      .card .meta .tags {
+        position: absolute;
+        bottom: 0;
+      }
+
+      .card .meta .tags .tag-label {
+        font-size: 1em;
+      }
     }
 
     .profile div img{

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -25,14 +25,21 @@
   #search{
     height: 60px;
     padding: 10px 0;
-  }
-  #search .form-group{
-    padding: 0 8px;
-  }
-  #search button, #search input{
-    width: 100%;
+
+    .form-group{
+      padding: 0 8px;
+    }
+
+    button, input{
+      width: 100%;
+    }
   }
 }
+
+#search {
+   background-color: #f8f8f8;
+}
+
 
  /* OVERRIDE BOOTSTRAP ANCHOR BEHAVIOR */
  a {
@@ -154,6 +161,10 @@ img.logo{
 
   .navbar{
     margin-bottom: 0;
+  }
+
+  .navbar-brand {
+    padding: 10px;
   }
 
   .form-search{

--- a/app/views/application/_landing.html.haml
+++ b/app/views/application/_landing.html.haml
@@ -1,103 +1,25 @@
-:css
-  @import url(//fonts.googleapis.com/css?family=Arvo:700);
-  .background {
-    background:url('../img/bg/diagonalnoise.png');
-    position: relative;
-  }
-
-  .layer {
-    background-color: rgba(134, 198, 124, 0.85);
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 108.1%;
-    height: 25%;
-    margin-top: 20.1%
-  }
-  .layer1 {
-    background-color: rgba(134, 198, 124, 0.92);
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 108.1%;
-    height: 25%;
-    margin-top: 20.1%
-  }
-  .left-padding{
-    padding-left: 10px
-  }
-%meta{:content => "width=device-width, initial-scale=1", :name => "viewport"}
-.container
-  .row{:style=>"margin-bottom:10%"}
-    .p{:style=>"margin-top:-10%;padding:0 10% 0 10%"}
-    .col-md-5
-      .h2{:style=>"text-align:center;margin-bottom:10%;font-family: 'Work Sans', sans-serif;font-size:250%;"}
-        =link_to "Methods", design_methods_path
-      .row
-        %p.subtitle{:style=>"text-align:center;font-size:100%; margin-top:-10%;font-family: 'Source Sans Pro', sans-serif;"} Learn about the methods you could use on your next design.
-        .background
-        = link_to design_method_path(id: 162) do 
-          = image_tag "MethodLandingPage.jpg", :width => "100%", size: "450x370"
-          .layer1
-            .left-padding
-              .h1{:style=>"margin-bottom:10%;font-family: 'Work Sans', sans-serif;color: white"}
-                Cultural Probes
-              .h4{:style=>"margin-bottom:10%;font-size:100%;color: white;margin-top:-10%;"}
-                Gain insight into and inspirational responses about the daily life and habits of communities
-
-    .col-md-2
-    .col-md-5
-      .h2{:style=>"text-align:center;margin-bottom:10%;font-family: 'Work Sans', sans-serif;font-size:250%;"}
-        =link_to "Case Studies", case_studies_path
-      .row
-        / %p.subtitle{:style=>"text-align:center;font-size:100%; margin-top:-10%;font-family: 'Source Sans Pro', sans-serif;"} Read about how real design probems were solved.
-        %p.subtitle{:style=>"text-align:center;font-size:200%; margin-top:30%;font-family: 'Source Sans Pro', sans-serif;"} Case Studies coming soon
-        .background
-        / = link_to case_study_path(id:197) do #change link path
-        /   = image_tag "CaseStudiesLandingPage.png", :width => "100%", size: "450x370"
-        /   .layer
-        /     .left-padding
-        /       .h1{:style=>"margin-bottom:10%;font-family: 'Work Sans';font-size:180%; sans-serif;color: white;"}
-        /         Adapting Usability Testing for Oral, Rural Users
-        /       .h4{:style=>"margin-bottom:10%;font-size:100%;color: white;margin-top:-10%;"}
-        /         Read about a study conducted in Ghanaian villages that evaluated an audio computer desgined for people living in oral cultures
-
-
-  
-
-  /. Landing
-  / .thedxcommunity{:style=>"margin-top:60%;padding:0 10% 0 10%"}
-  /   %hr/x
-  /   .h2{:style=>"text-align:center; font-size:2em;margin-bottom:10%;"}
-  /     The Design Exchange Community
-  /   .col-md-4
-  /     .thumbnail{:style=>"text-align:center; font-size:1em"}
-  /       - if User.find_by(id:1).profile_picture.present?
-  /         = image_tag(user.profile_picture, class: "img-responsive", :style => "padding: 5%")
-  /       - else
-  /         = image_tag("no-profile-available.jpg", class: "img-responsive" , :style => "padding: 5%", :size=>"150x150")
-  /       .h3
-  /         First Last
-  /       .p
-  /         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-
-
-  /   .col-md-4
-  /     .thumbnail{:style=>"text-align:center; font-size:1em"}
-  /       = image_tag("no-profile-available.jpg", class: "img-responsive" , :style => "padding: 5%", :size=>"150x150")
-  /       .h3
-  /         First Last
-  /       .p
-  /         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-
-
-  /   .col-md-4
-  /     .thumbnail{:style=>"text-align:center; font-size:1em"}
-  /       = image_tag("no-profile-available.jpg", class: "img-responsive" , :style => "padding: 5%", :size=>"150x150")
-  /       .h3
-  /         First Last
-  /       .p
-  /         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-
-
-
+= stylesheet_link_tag "_landing", :media => "all" # CSS is in this file!
+.row{:id => "showcase"}
+  .col-sm-6
+    %h1
+      =link_to "Methods", design_methods_path
+    %p.subtitle Learn about the methods you could use on your next design.
+    .background{:id => "method-background"}
+      .layer
+        %h2
+          Cultural Probes
+        %h4
+          Gain insight into and inspirational responses about the daily life and habits of communities
+  .col-sm-6
+    %h1
+      =link_to "Case Studies", case_studies_path
+    / %p.subtitle{:style=>"text-align:center;font-size:100%; margin-top:-10%;font-family: 'Source Sans Pro', sans-serif;"} Read about how real design probems were solved.
+    %p.subtitle{:style=>"text-align:center;font-size:200%; margin-top:30%;font-family: 'Source Sans Pro', sans-serif;"} Case Studies coming soon
+    / = link_to case_study_path(id:197) do #change link path
+    /   = image_tag "CaseStudiesLandingPage.png", :width => "100%", size: "450x370"
+    /   .layer
+    /     .left-padding
+    /       .h1{:style=>"margin-bottom:10%;font-family: 'Work Sans';font-size:180%; sans-serif;color: white;"}
+    /         Adapting Usability Testing for Oral, Rural Users
+    /       .h4{:style=>"margin-bottom:10%;font-size:100%;color: white;margin-top:-10%;"}
+    /         Read about a study conducted in Ghanaian villages that evaluated an audio computer desgined for people living in oral cultures

--- a/app/views/case_studies/index.html.haml
+++ b/app/views/case_studies/index.html.haml
@@ -2,11 +2,32 @@
   $(function(){
     var pH = $('#create-btn').parent().parent().height()
     var eH = $('#create-btn').height()
-    $('#create-btn').css('margin-top', (pH - eH)/2)
     $('#hidden').click(function() {
       $("#hiddenCaseStudies").toggle();
     });
   });
+:css
+  html, body{
+  	height: 100%;
+  	width: 100%;
+  }
+  #search-and-filter{
+  	height: 100%;
+  }
+
+  #create-btn{
+    float: right;
+    margin: 16px 0 10px 0;
+  }
+
+  @media (max-width: 768px) {
+    #create-btn {
+      float: none;
+      margin: auto;
+      display: table;
+    }
+  }
+
 .container-fluid
   .row
     .col-md-2
@@ -16,7 +37,7 @@
           - if params[:filter_category] == nil
             = "Featured Case Studies"
           - else
-            = "Case Studies: " + filter_category(params[:filter_category]) 
+            = "Case Studies: " + filter_category(params[:filter_category])
 
 
         - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
@@ -24,27 +45,27 @@
           %br
           = link_to "Sort by Completion Score", {:controller => "case_studies", :action => "index", :sort_order => "completion"}, :class => "btn btn-primary"
       .col-md-6
-        = link_to new_case_study_path, :id => "create-btn", :class => "btn btn-default pull-right btn-index-create"  do
+        = link_to new_case_study_path, :id => "create-btn", :class => "btn btn-default btn-index-create"  do
           %span.glyphicon.glyphicon-plus
           Add Case Study
-  
+
   .row
-    #sidebar.col-xs-4.col-sm-2
+    #sidebar.col-sm-2
       = render "/layouts/sidebarcase"
     - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
-      .col-md-2
+      .col-sm-2
         / WARNING: SIDEBAR UNDER CONSTRUCTION!
-      .col-md-10.left-pad
-        #hiddenCaseStudies{:style => "display:none"} 
-          .h4{:style => "margin-left:3%"}
+      .col-sm-10.left-pad
+        #hiddenCaseStudies{:style => "display:none"}
+          %h4{:style => "margin-left:3%"}
             Hidden Case Studies
           - @case_studies.where(:hidden => true).where(:draft=>false).each do |cs|
             = render "/layouts/thumbnail", :object => @thumb_obj = thumbnail(cs,"3")
-    .col-md-2
-    .col-md-10.left-pad
+    .col-sm-2
+    .col-sm-10.left-pad
       - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
         #publicCaseStudies
-          .h4{:style => "margin-left:3%"}
+          %h4{:style => "margin-left:3%"}
             Public Case Studies
       - @case_studies.where(:hidden => false).where(:draft=>false).each do |cs|
         = render "/layouts/thumbnail", :object => @thumb_obj = thumbnail(cs,"3")

--- a/app/views/design_methods/index.html.haml
+++ b/app/views/design_methods/index.html.haml
@@ -3,7 +3,6 @@
     // Archaeologist's note: this seems like a spectacularly bad idea, not spending the time to figure it out right now
   	var pH = $('#create-btn').parent().parent().height()
   	var eH = $('#create-btn').height()
-  	$('#create-btn').css('margin-top', (pH - eH)/2)
     $('#hidden').click(function() {
       $("#hiddenMethods").toggle(this.checked);
     });
@@ -22,58 +21,70 @@
   	margin-left: 0;
   	padding-left: 0;
   }
+
+  #create-btn{
+    float: right;
+    margin: 16px 0 10px 0;
+  }
+
+  @media (max-width: 768px) {
+    #create-btn {
+      float: none;
+      margin: auto;
+      display: table;
+    }
+  }
 / TOP ROW
 .container-fluid
   .row
-    .col-xs-8.col-xs-offset-4.col-sm-10.col-sm-offset-2.left-pad
-      .col-xs-6
+    .col-sm-10.col-sm-offset-2.left-pad
+      .col-sm-6
 
-        .h3 
+        %h3
           / = params[:filter_category]
           - if params[:filter_category] == nil
             = "Methods"
-          - else 
-            = "Methods: " + filter_category(params[:filter_category]) 
+          - else
+            = "Methods: " + filter_category(params[:filter_category])
         - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
           %input{:name => "hidden", :type => "checkbox", :id => "hidden", :style => "margin: 0px 5px 15px 0px"} Show hidden methods
           %br
           = link_to "Sort by Completion Score", {:controller => "design_methods", :action => "index", :sort_order => "completion"}, :class => "btn btn-primary"
 
-      .col-xs-6
-        = link_to new_design_method_path, :id=> "create-btn", :class=> "btn btn-default pull-right btn-index-create" do
+      .col-sm-6
+        = link_to new_design_method_path, :id=> "create-btn", :class=> "btn btn-default btn-index-create" do
           %span.glyphicon.glyphicon-plus
           Create Method
 
   / END TOP ROW
   #search-and-filter.row
-    #sidebar.col-xs-4.col-sm-2
+    #sidebar.col-sm-2
       = render "/layouts/sidebar"
     - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
-      #results-container.col-xs-8.col-sm-10
+      #results-container.col-sm-10
         #hiddenMethods{:style => "display:none"}
-          .h4{:style => "margin-left:3%"}
+          %h4{:style => "margin-left:3%"}
             Hidden Methods
           - @design_methods.where(:hidden => true).where(:draft=>false).each do |method|
             = render "/layouts/thumbnail", :object => @thumb_obj = thumbnail(method,"3")
     - elsif current_user != nil && !@design_methods.where(:owner => current_user).empty?# signed in basic user with created methods
-      #results-container.col-xs-8.col-sm-10
+      #results-container.col-sm-10
         #hiddenMethods
-          .h4{:style => "margin-left:3%"}
+          %h4{:style => "margin-left:3%"}
             My Hidden Methods
-          .h5{:style => "margin-left:3%"}
+          %h5{:style => "margin-left:3%"}
             An admin or editor has to approve these for public visibility
           - @design_methods.where(:owner => current_user).where(:hidden => true).each do |method|
             = render "/layouts/thumbnail", :object => @thumb_obj = thumbnail(method,"3")
-    #sidebar.col-xs-4.col-sm-2
 
-    #results-container.col-xs-8.col-sm-10
+    #results-container.col-sm-10
       - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
         #publicMethods
-          .h4{:style => "margin-left:3%"}
+          %h4{:style => "margin-left:3%"}
             Public Methods
       - elsif current_user != nil && !@design_methods.where(:owner => current_user).empty?# signed in basic user with created methods
         #publicMethods
-          .h4{:style => "margin-left:3%"}
+          %h4{:style => "margin-left:3%"}
             Public Methods
 
       - @design_methods.where(:hidden => false).where(:draft=>false).each do |method|

--- a/app/views/design_methods/show.html.haml
+++ b/app/views/design_methods/show.html.haml
@@ -357,7 +357,6 @@
 
     - if @method.references != nil and @method.references != ''
       %h4 References used in this Article
-      -# %p= @method.references
       %p= md_format(@method.references)
     / - if @citations != nil && @citations.length != 0
     /   %h3 Citations

--- a/app/views/design_methods/show.html.haml
+++ b/app/views/design_methods/show.html.haml
@@ -122,9 +122,9 @@
         = tagify(t.id, t.content, {:removable => false})
       = "No tags available" unless not @method.tags.empty?
   - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
-    .row 
+    .row
       %h4 Completion Score
-      %p 
+      %p
         /calculate the completion score if it has not been done already
         - score = 0
         - for attribute in @design_method.attributes.keys
@@ -133,7 +133,7 @@
         - @design_method.completion_score = score
         - @design_method.save
         = score
-       
+
   .row
     %h4 Characteristics
     - @method.method_categories.each do |category|
@@ -200,22 +200,22 @@
       - if current_user != nil and (current_user.admin? or current_user.editor?) and @design_method.editor_id == current_user.id
         = link_to "Unclaim to be Editor", {:controller => "design_methods", :action => :unclaimEditor, :id => @design_method.id}, :class => "btn btn-success"
 
-    
+
       - if current_user != nil and (current_user.admin? or current_user.editor? or current_user.author?) and @design_method.author_id == nil
         = link_to "Claim to be Author", {:controller => "design_methods", :action => :claimAuthor, :id => @design_method.id}, :class => "btn btn-success"
 
       - if current_user != nil and (current_user.admin? or current_user.editor? or current_user.author?) and @design_method.author_id == current_user.id
-        = link_to "Unclaim to be Author", {:controller => "design_methods", :action => :unclaimAuthor, :id => @design_method.id}, :class => "btn btn-success" 
+        = link_to "Unclaim to be Author", {:controller => "design_methods", :action => :unclaimAuthor, :id => @design_method.id}, :class => "btn btn-success"
 
       %p{:style=>"text-align: right; font-size: 11px;"}
-        Last Updated: 
+        Last Updated:
         - if @design_method.last_edited != nil
           #{@design_method.last_edited.strftime('%x %I:%M %p')} by
           #{@design_method.last_editor}
         - else
           Before 10/18/2016
 
-         
+
 
     /Method top level categories
   .row
@@ -252,7 +252,7 @@
       = image_tag(@method.image_url, :width => "100%")
 
     / Displays image attribution
-    - if !@method.image_attribution.blank? 
+    - if !@method.image_attribution.blank?
       %h5 Image Attributions
       %p
         = md_format(@method.image_attribution)
@@ -308,7 +308,7 @@
       .col-xs-8
         %p= link_to @author.first_name + " " + @author.last_name, user_path(@author.id)
         %p= @author.email != nil ? @author.email : "-"
-    
+
     - if @current_author != nil
       .col-xs-6
         %h5 Current Author
@@ -318,7 +318,7 @@
           - else
             /TODO lol we need to self host this asap
             = image_tag("https://s3-us-west-1.amazonaws.com/thedesignexchange-staging/anonymous_silhouette.jpg", class: "fit-all",:style => "padding: 10%")
-        .col-xs-8 
+        .col-xs-8
           - if @current_author != nil
             %p= link_to @current_author.first_name + " " + @current_author.last_name, user_path(@current_author.id)
             %p= @current_author.email != nil ? @current_author.email : "-"
@@ -331,7 +331,7 @@
           - else
             /TODO lol we need to self host this asap
             = image_tag("https://s3-us-west-1.amazonaws.com/thedesignexchange-staging/anonymous_silhouette.jpg", class: "fit-all",:style => "padding: 10%")
-        .col-xs-8 
+        .col-xs-8
           - if @current_editor != nil
             %p= link_to @current_editor.first_name + " " + @current_editor.last_name, user_path(@current_editor.id)
             %p= @current_editor.email != nil ? @current_editor.email : "-"
@@ -357,7 +357,7 @@
 
     - if @method.references != nil and @method.references != ''
       %h4 References used in this Article
-      %p= @method.references
+      -# %p= @method.references
       %p= md_format(@method.references)
     / - if @citations != nil && @citations.length != 0
     /   %h3 Citations
@@ -381,4 +381,3 @@
       %h4 Related Case Studies
       - @method.case_studies.each do |cs|
         = render "/layouts/thumbnail", locals: @thumb_obj = thumbnail(cs,"4")
-

--- a/app/views/layouts/_deheader.html.haml
+++ b/app/views/layouts/_deheader.html.haml
@@ -24,7 +24,7 @@
         .boxed
           %h2
             Learn
-          .p
+          %p
             Browse methods and case studies to improve your design skills. Learn what to
             do and what not to do to successfully complete your next design task.
 
@@ -34,5 +34,5 @@
           %h2
             %a{:href=>"/share"}
               Invite
-          .p
+          %p
             Invite your friends to join theDesignExchange community!

--- a/app/views/layouts/_deheader.html.haml
+++ b/app/views/layouts/_deheader.html.haml
@@ -4,85 +4,35 @@
     $("form#search input").autocomplete(DE.Autocomplete);
   });
 
-:css
-  @import url(//fonts.googleapis.com/css?family=Arvo:700);
-  .header-font {
-    font-family: 'Arvo', serif;
-  }
-  .h1 {
-    font-size = font-size: 300%;
-  }
-  .jumbotron {
-    font-size: 17px;
-    background: rgb(89, 88, 91);
-    color: white;
-  }
-  .subtitle {
-    font-size: 20px;
-    margin-top:2%;
-  }
-
-  .login-margin {
-    margin-left: 25%;
-    margin-right: 25%;
-    margin-top: 5%;
-  }
-
-  .btn.sharp {
-    border-radius:0;
-    letter-spacing: 2px;
-    padding: 10px 50px;
-  }
-  .logo{
-    width: 300px;
-  }
-  .header {
-    padding: 25px 10px;
-    height: 55px;
-    border-bottom: 1px solid #d3d3d3;
-    overflow: no-content;
-    min-width: 400px;
-  }
-  .#header-right {
-    width: 50%;
-    border-color: blue;
-  }
-  .btn-xl {
-    padding: 18px 28px;
-    font-size: 22px;
-    border-radius: 10px;
-  }
-
 %link{:href => "https://fonts.googleapis.com/css?family=Work+Sans:700", :rel => "stylesheet"}/
 %link{:href => "https://fonts.googleapis.com/css?family=Source+Sans+Pro", :rel => "stylesheet"}/
+= stylesheet_link_tag "_deheader", :media => "all"
 
-
-.jumbotron{:style=>"height:400px"}
+.jumbotron
   .container
     .row
-      .col-md-7
-        %h1.header-font
-          = image_tag "logo2.png", size: "600x54"
+      .col-sm-7
+        .header-img
+          = image_tag "logo2.png"
         %p.subtitle Where designers and researchers share methods and best practices.
-        .row
-        %br/
-        %br/
         .row
         - if !user_signed_in?
           .col-sm-3
-          .col-md-3= link_to "JOIN", new_registration_path(:user), class: "btn btn-success sharp btn-lrg", style: "font-family: 'Work Sans', sans-serif;height:50px; font-size:150%;"
-      .col-md-5.hidden-xs
-        .boxed{:style=>"border: 2px solid #009966;width: 350px;margin: auto;padding: 15px;border-radius: 25px;margin-top:-10%;"}
-          .p{:style=>"font-family: 'Work Sans', sans-serif;font-size:165%;"}
+          .col-sm-3
+            = link_to "JOIN", new_registration_path(:user), class: "btn btn-success sharp btn-lrg join"
+      .col-sm-5
+        .boxed
+          %h2
             Learn
-          .p{:style=>"font-size:100%;font-family: 'Source Sans Pro', sans-serif;"}
+          .p
             Browse methods and case studies to improve your design skills. Learn what to
             do and what not to do to successfully complete your next design task.
 
         %br/
 
-        .boxed{:style=>"border: 2px solid #009966;width: 350px;margin: auto;padding: 20px;border-radius: 25px;"}
-          %a{:href=>"/share",:style=>"font-family: 'Work Sans', sans-serif; font-size:165%"}
-            Invite
-          .p{:style=>"font-size:100%;font-family: 'Source Sans Pro', sans-serif;"}
+        .boxed
+          %h2
+            %a{:href=>"/share"}
+              Invite
+          .p
             Invite your friends to join theDesignExchange community!

--- a/app/views/layouts/_deheader.html.haml
+++ b/app/views/layouts/_deheader.html.haml
@@ -42,10 +42,10 @@
     border-bottom: 1px solid #d3d3d3;
     overflow: no-content;
     min-width: 400px;
-  }     
+  }
   .#header-right {
     width: 50%;
-    border-color: blue; 
+    border-color: blue;
   }
   .btn-xl {
     padding: 18px 28px;
@@ -57,7 +57,7 @@
 %link{:href => "https://fonts.googleapis.com/css?family=Source+Sans+Pro", :rel => "stylesheet"}/
 
 
-.jumbotron.hidden-xs{:style=>"height:400px;"}
+.jumbotron{:style=>"height:400px"}
   .container
     .row
       .col-md-7
@@ -71,12 +71,12 @@
         - if !user_signed_in?
           .col-sm-3
           .col-md-3= link_to "JOIN", new_registration_path(:user), class: "btn btn-success sharp btn-lrg", style: "font-family: 'Work Sans', sans-serif;height:50px; font-size:150%;"
-      .col-md-5
+      .col-md-5.hidden-xs
         .boxed{:style=>"border: 2px solid #009966;width: 350px;margin: auto;padding: 15px;border-radius: 25px;margin-top:-10%;"}
           .p{:style=>"font-family: 'Work Sans', sans-serif;font-size:165%;"}
             Learn
           .p{:style=>"font-size:100%;font-family: 'Source Sans Pro', sans-serif;"}
-            Browse methods and case studies to improve your design skills. Learn what to 
+            Browse methods and case studies to improve your design skills. Learn what to
             do and what not to do to successfully complete your next design task.
 
         %br/
@@ -86,9 +86,3 @@
             Invite
           .p{:style=>"font-size:100%;font-family: 'Source Sans Pro', sans-serif;"}
             Invite your friends to join theDesignExchange community!
-                
-    
-
-
-
-  

--- a/app/views/layouts/_headernav.html.haml
+++ b/app/views/layouts/_headernav.html.haml
@@ -58,7 +58,7 @@
             = link_to "Sign In", new_user_session_path, :class => 'navbar-link', style: "font-size: 120%;"
 
 // display flash errors if any
-.notice{:style=>"margin-top:50px;"}
+.notice
   - flash.each do |type, msg|
     - type = :success if type == :notice
     = content_tag(:div, msg, class: "flash-alert alert alert-#{type}")

--- a/app/views/layouts/_headernav.html.haml
+++ b/app/views/layouts/_headernav.html.haml
@@ -66,4 +66,3 @@
   - flash.each do |type, msg|
     - type = :success if type == :notice
     = content_tag(:div, msg, class: "flash-alert alert alert-#{type}")
-

--- a/app/views/layouts/_headernav.html.haml
+++ b/app/views/layouts/_headernav.html.haml
@@ -3,11 +3,7 @@
     $('form#search input').autocomplete(DE.Autocomplete);
   });
 
-:css
-  .navbar-fixed-top {
-      height: 60px;
-  }
-
+%meta{:content => "width=device-width, initial-scale=1", :name => "viewport"}
 %nav.navbar.navbar-default.navbar-fixed-top{:role => "navigation"}
   .container-fluid
     / Brand and toggle get grouped for better mobile display

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -11,6 +11,7 @@
   }
 :css
   .sidebar-element{
+    margin-bottom: 5px;
   }
 
   .sidebar-leaf{
@@ -21,20 +22,32 @@
   .sidebar-maincategory{
   	font-weight: bold;
     cursor: pointer;
-
   }
 
-  #sidebar{
+  .sidebar{
      text-decoration: none;
      cursor: pointer;
      overflow: hidden;
      margin-right: 0;
      padding-right: 0px;
-     /*width: 100%;*/
-     height: 100%;
-     /*border-right: 2px solid #ddd;*/
   }
-.h5{:style=>"margin-left:40px"} Filter by Design Process
+
+  .sidebar h5 {
+    margin-left:40px;
+  }
+
+  @media (max-width: 768px) {
+    .sidebar-element {
+      display: inline-block;
+      padding-left: 10px;
+    }
+
+    .sidebar h5 {
+      margin-left: 0px;
+    }
+  }
+
+%h5 Filter by Design Process
 - @search_filter_hash.each do |x|
   %ul.sidebar-element
     .category

--- a/app/views/layouts/_sidebarcase.html.haml
+++ b/app/views/layouts/_sidebarcase.html.haml
@@ -25,7 +25,7 @@
 
   }
 
-  #sidebar{
+  .sidebar{
 
      text-decoration: none;
      cursor: pointer;
@@ -36,7 +36,23 @@
      height: 100%;
      /*border-right: 2px solid #ddd;*/
   }
-.h5{:style=>"margin-left:40px"} Filter by Design Process
+
+  .sidebar h5 {
+    margin-left: 40px;
+  }
+
+  @media (max-width: 768px) {
+    .sidebar-element {
+      display: inline-block;
+      padding-left: 10px;
+      margin-right: 0px;
+    }
+
+    .sidebar h5 {
+      margin-left: 0px;
+    }
+  }
+%h5 Filter by Design Process
 - @search_filter_hash.each do |x|
   %ul.sidebar-element
     .category

--- a/app/views/layouts/_thumbnail.html.haml
+++ b/app/views/layouts/_thumbnail.html.haml
@@ -1,3 +1,3 @@
 / STYLE at APPLICATION.CSS ... THUMBNAIL CSS
-%div{:class => "col-xs-4 col-sm-4 col-md-#{@thumb_obj[:col_md_value]} left-top-padding"}
+%div{:class => "col-sm-4 col-md-#{@thumb_obj[:col_md_value]} left-top-padding"}
   = render "/application/thumbnail_core", :object => @thumb_obj = @thumb_obj

--- a/app/views/layouts/custom.html.haml
+++ b/app/views/layouts/custom.html.haml
@@ -30,16 +30,12 @@
         margin-right: 25%;
         margin-top: 5%;
       }
-      .container {
-        position: relative;
-        top: 50px;
-      }
       .footer{
         position:relative;
         bottom:0;
         width:100%;
         height:60px;   /* Height of the footer */
-        margin-top:100px;
+        margin-top:30px;
       }
 
 

--- a/app/views/layouts/custom.html.haml
+++ b/app/views/layouts/custom.html.haml
@@ -38,6 +38,11 @@
         margin-top:30px;
       }
 
+      @media (max-width: 768px) {
+        .login-margin {
+          margin: 5% 0 0 0;
+        }
+      }
 
     = render "layouts/headernav"
     / Header for the application#index view


### PR DESCRIPTION
I started with the front page.
![image](https://cloud.githubusercontent.com/assets/9982665/23438056/3df152b4-fdc5-11e6-94ad-ac56bd4d0466.png)
There were quite a few unnecessary elements, so I cleaned up the html. I also moved all the CSS in _headernav, _deheader, _landing, to their respective CSS files (creating new files if I had to). I didn't like all the empty space so I compressed it a bit. The change is barely noticeable from the front end. Here's how it looks now:
![image](https://cloud.githubusercontent.com/assets/9982665/23438148/99a41d62-fdc5-11e6-8a34-8c3a60e235a3.png)
On mobile, there were a couple of issues. The jumbotron would disappear, and the page would extend beyond the boundaries of the phone. Turns out this was because the images were fixed size. 
![image](https://cloud.githubusercontent.com/assets/9982665/23438231/e9fb63ec-fdc5-11e6-8626-442bbf8086b9.png)
I brought the jumbotron back and fixed issues with image size and "Cultural Probes" not sticking directly above the image. It's better to make the image a background image and place the "Cultural Probes" text inside that div.
![image](https://cloud.githubusercontent.com/assets/9982665/23438235/f035051a-fdc5-11e6-9335-e0f3c00bacb4.png)
Methods and case studies were similarly modified to be optimized for mobile view. Before, you had to zoom into the page because it was desktop view on a smaller screen
![image](https://cloud.githubusercontent.com/assets/9982665/23438342/56c49840-fdc6-11e6-8a63-103dd3ac4373.png)
After:
![image](https://cloud.githubusercontent.com/assets/9982665/23438426/a319b928-fdc6-11e6-94ef-dd2d5ca641b7.png)
To be honest, I don't like the top of the page. I'll consult someone about improving that later.

I probably still need to do some things with pages you can access upon login. Let me know if you need things changed.