### PR TITLE
Responsive feature

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -273,13 +273,14 @@ img.logo{
 
     @media (max-width: 768px) {
       .card {
-        height: 150px;
-        margin: 10px 0 10px 0;
-      }
-
-      .card .meta .tags {
-        position: absolute;
-        bottom: 0;
+        height: 190px;
+        margin: 16px 0 16px 0;
+        .caption h5 {
+          font-size: 1.5em;
+        }
+        .caption p {
+          font-size: 1.2em;
+        }
       }
 
       .card .meta .tags .tag-label {

--- a/app/views/application/_thumbnail_core.html.haml
+++ b/app/views/application/_thumbnail_core.html.haml
@@ -28,23 +28,23 @@
           - if counter == 2
             - break
           %span.tag-label.label-gap
-            = MethodCategory.find_by(id:category).name 
+            = MethodCategory.find_by(id:category).name
           / - case category
           / - when 1
           /   %span.tag-label.label-gap{:style=>"color:beige"}
           /     = MethodCategory.find_by(id:category).name
           / - when 2
           /   %span.tag-label.label-gap{:style=>"color:aqua"}
-          /     = MethodCategory.find_by(id:category).name      
+          /     = MethodCategory.find_by(id:category).name
           / - when 3
           /   %span.tag-label.label-gap{:style=>"color:cyan"}
-          /     = MethodCategory.find_by(id:category).name 
+          /     = MethodCategory.find_by(id:category).name
           / - when 4
           /   %span.tag-label.label-gap{:style=>"color:yellow"}
-          /     = MethodCategory.find_by(id:category).name 
+          /     = MethodCategory.find_by(id:category).name
           / - when 5
           /   %span.tag-label.label-gap{:style=>"color:coral"}
-          /     = MethodCategory.find_by(id:category).name     
+          /     = MethodCategory.find_by(id:category).name
           / - counter += 1
     %br
 

--- a/app/views/case_studies/index.html.haml
+++ b/app/views/case_studies/index.html.haml
@@ -8,64 +8,66 @@
   });
 :css
   html, body{
-  	height: 100%;
-  	width: 100%;
+    height: 100%;
+    width: 100%;
   }
   #search-and-filter{
-  	height: 100%;
+    height: 100%;
   }
 
-  #create-btn{
-    float: right;
-    margin: 16px 0 10px 0;
+  #results-container{
+    margin-left: 0;
+    padding-left: 0;
+  }
+
+  #create{
+    position: absolute;
+    right: 0;
+    top: 12px;
   }
 
   @media (max-width: 768px) {
+    #create {
+      position: relative;
+      top: auto;
+      display: inline-block;
+    }
+
     #create-btn {
-      float: none;
-      margin: auto;
-      display: table;
+      margin-top: 0;
     }
   }
 
 .container-fluid
   .row
-    .col-md-2
-    .col-md-10.left-pad
-      .col-md-6
-        .h3
-          - if params[:filter_category] == nil
-            = "Featured Case Studies"
-          - else
-            = "Case Studies: " + filter_category(params[:filter_category])
+    .h3
+      - if params[:filter_category] == nil
+        = "Featured Case Studies"
+      - else
+        = "Case Studies: " + filter_category(params[:filter_category])
 
 
-        - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
-          %input{:name => "hidden", :type => "checkbox", :id => "hidden", :style => "margin: 0px 5px 15px 0px"} Show hidden Case Studies
-          %br
-          = link_to "Sort by Completion Score", {:controller => "case_studies", :action => "index", :sort_order => "completion"}, :class => "btn btn-primary"
-      .col-md-6
+    - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
+      %input{:name => "hidden", :type => "checkbox", :id => "hidden", :style => "margin: 0px 5px 15px 0px"} Show hidden Case Studies
+      %br
+      = link_to "Sort by Completion Score", {:controller => "case_studies", :action => "index", :sort_order => "completion"}, :class => "btn btn-primary"
+      #create
         = link_to new_case_study_path, :id => "create-btn", :class => "btn btn-default btn-index-create"  do
           %span.glyphicon.glyphicon-plus
           Add Case Study
 
   .row
-    #sidebar.col-sm-2
+    #sidebar
       = render "/layouts/sidebarcase"
     - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
-      .col-sm-2
-        / WARNING: SIDEBAR UNDER CONSTRUCTION!
-      .col-sm-10.left-pad
-        #hiddenCaseStudies{:style => "display:none"}
-          %h4{:style => "margin-left:3%"}
-            Hidden Case Studies
-          - @case_studies.where(:hidden => true).where(:draft=>false).each do |cs|
-            = render "/layouts/thumbnail", :object => @thumb_obj = thumbnail(cs,"3")
-    .col-sm-2
-    .col-sm-10.left-pad
-      - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
-        #publicCaseStudies
-          %h4{:style => "margin-left:3%"}
-            Public Case Studies
-      - @case_studies.where(:hidden => false).where(:draft=>false).each do |cs|
-        = render "/layouts/thumbnail", :object => @thumb_obj = thumbnail(cs,"3")
+      #hiddenCaseStudies{:style => "display:none"}
+        %h4{:style => "margin-left:3%"}
+          Hidden Case Studies
+        - @case_studies.where(:hidden => true).where(:draft=>false).each do |cs|
+          = render "/layouts/thumbnail", :object => @thumb_obj = thumbnail(cs,"3")
+    - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
+      #publicCaseStudies
+        %h4{:style => "margin-left:3%"}
+          Public Case Studies
+    - @case_studies.where(:hidden => false).where(:draft=>false).each do |cs|
+      = render "/layouts/thumbnail", :object => @thumb_obj = thumbnail(cs,"3")

--- a/app/views/design_methods/index.html.haml
+++ b/app/views/design_methods/index.html.haml
@@ -1,8 +1,8 @@
 :javascript
   $(function(){
     // Archaeologist's note: this seems like a spectacularly bad idea, not spending the time to figure it out right now
-  	var pH = $('#create-btn').parent().parent().height()
-  	var eH = $('#create-btn').height()
+    var pH = $('#create-btn').parent().parent().height()
+    var eH = $('#create-btn').height()
     $('#hidden').click(function() {
       $("#hiddenMethods").toggle(this.checked);
     });
@@ -10,65 +10,66 @@
   });
 :css
   html, body{
-  	height: 100%;
-  	width: 100%;
+    height: 100%;
+    width: 100%;
   }
   #search-and-filter{
-  	height: 100%;
+    height: 100%;
   }
 
   #results-container{
-  	margin-left: 0;
-  	padding-left: 0;
+    margin-left: 0;
+    padding-left: 0;
   }
 
-  #create-btn{
-    float: right;
-    margin: 16px 0 10px 0;
+  #create{
+    position: absolute;
+    right: 0;
+    top: 12px;
   }
 
   @media (max-width: 768px) {
+    #create {
+      position: relative;
+      top: auto;
+      display: inline-block;
+    }
+
     #create-btn {
-      float: none;
-      margin: auto;
-      display: table;
+      margin-top: 0;
     }
   }
 / TOP ROW
 .container-fluid
   .row
-    .col-sm-10.col-sm-offset-2.left-pad
-      .col-sm-6
-
-        %h3
-          / = params[:filter_category]
-          - if params[:filter_category] == nil
-            = "Methods"
-          - else
-            = "Methods: " + filter_category(params[:filter_category])
-        - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
-          %input{:name => "hidden", :type => "checkbox", :id => "hidden", :style => "margin: 0px 5px 15px 0px"} Show hidden methods
-          %br
-          = link_to "Sort by Completion Score", {:controller => "design_methods", :action => "index", :sort_order => "completion"}, :class => "btn btn-primary"
-
-      .col-sm-6
-        = link_to new_design_method_path, :id=> "create-btn", :class=> "btn btn-default btn-index-create" do
-          %span.glyphicon.glyphicon-plus
-          Create Method
+    %h3
+      / = params[:filter_category]
+      - if params[:filter_category] == nil
+        = "Methods"
+      - else
+        = "Methods: " + filter_category(params[:filter_category])
+    - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
+      %input{:name => "hidden", :type => "checkbox", :id => "hidden", :style => "margin: 0px 5px 15px 0px"} Show hidden methods
+      %br
+      = link_to "Sort by Completion Score", {:controller => "design_methods", :action => "index", :sort_order => "completion"}, :class => "btn btn-primary"
+    #create
+      = link_to new_design_method_path, :id=> "create-btn", :class=> "btn btn-default btn-index-create" do
+        %span.glyphicon.glyphicon-plus
+        Create Method
 
   / END TOP ROW
   #search-and-filter.row
-    #sidebar.col-sm-2
+    #sidebar
       = render "/layouts/sidebar"
     - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
-      #results-container.col-sm-10
+      #results-container
         #hiddenMethods{:style => "display:none"}
           %h4{:style => "margin-left:3%"}
             Hidden Methods
           - @design_methods.where(:hidden => true).where(:draft=>false).each do |method|
             = render "/layouts/thumbnail", :object => @thumb_obj = thumbnail(method,"3")
     - elsif current_user != nil && !@design_methods.where(:owner => current_user).empty?# signed in basic user with created methods
-      #results-container.col-sm-10
+      #results-container
         #hiddenMethods
           %h4{:style => "margin-left:3%"}
             My Hidden Methods
@@ -77,7 +78,7 @@
           - @design_methods.where(:owner => current_user).where(:hidden => true).each do |method|
             = render "/layouts/thumbnail", :object => @thumb_obj = thumbnail(method,"3")
 
-    #results-container.col-sm-10
+    #results-container
       - if (current_user != nil) && (current_user.admin? || current_user.editor? || current_user.author?)
         #publicMethods
           %h4{:style => "margin-left:3%"}

--- a/app/views/design_methods/show.html.haml
+++ b/app/views/design_methods/show.html.haml
@@ -16,6 +16,10 @@
     padding: 20px;
 
   }
+  #title {
+    height: 0;
+    float: right;
+  }
   #sidebar {
     padding-top: 50px;
   }
@@ -77,6 +81,31 @@
     white-space: nowrap;
     background: whitesmoke;
   }
+
+  @media (max-width: 768px) {
+    #title {
+      height: auto;
+      float: none;
+      padding: 0;
+    }
+    #sidebar {
+      padding-top: 0;
+    }
+
+    #sidebar h4 {
+      float: left;
+      margin: 5px 10px 5px;
+      font-size: 16px;
+    }
+    #sidebar p {
+      float: left;
+      margin: 2px 4px 3px 4px;
+    }
+
+    .content-column img {
+      width: 100%;
+    }
+  }
 :javascript
   $(document).ready(function() {
     $('.dropdown-menu input').click(function(e) {
@@ -95,6 +124,11 @@
     });
   });
 
+#title.col-md-9
+  - if @design_method.draft == true
+    %h3{:style=>"color:blue"}= @method.name
+  - else
+    %h3= @method.name
 
 #sidebar.col-md-3
   .row
@@ -146,10 +180,7 @@
   /Method header
   .row
     .col-md-6.no-padding
-      - if @design_method.draft == true
-        %h3{:style=>"color:blue"}= @method.name
-      - else
-        %h3= @method.name
+
 
     .col-md-6.pull-right
       .pull-right

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -10,21 +10,17 @@
               })
   }
 :css
-  .sidebar-element{
-    margin-bottom: 5px;
-  }
-
   .sidebar-leaf{
-  	font-weight: normal;
-  	display: block;
+    font-weight: normal;
+    display: block;
   }
 
   .sidebar-maincategory{
-  	font-weight: bold;
+    font-weight: bold;
     cursor: pointer;
   }
 
-  .sidebar{
+  #sidebar{
      text-decoration: none;
      cursor: pointer;
      overflow: hidden;
@@ -32,22 +28,40 @@
      padding-right: 0px;
   }
 
-  .sidebar h5 {
-    margin-left:40px;
+  .sidebar-element {
+    display: inline-block;
+    margin: 6px 0 0 0;
+    padding: 0;
+  }
+
+  .sidebar-element .category {
+    display: inline-block;
+    padding: .2em .6em .3em;
+    font-size: 14px;
+    font-weight: bold;
+    line-height: 1;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: 0.35em;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #366036;
+  }
+
+  #sidebar h5 {
+    float: left;
+    clear: left;
+    margin-right: 20px;
   }
 
   @media (max-width: 768px) {
-    .sidebar-element {
-      display: inline-block;
-      padding-left: 10px;
-    }
-
-    .sidebar h5 {
-      margin-left: 0px;
+    #sidebar h5 {
+      float: none;
     }
   }
 
-%h5 Filter by Design Process
+%h5 Filter by Design Process:
 - @search_filter_hash.each do |x|
   %ul.sidebar-element
     .category

--- a/app/views/layouts/_sidebarcase.html.haml
+++ b/app/views/layouts/_sidebarcase.html.haml
@@ -10,49 +10,58 @@
               })
   }
 :css
-  .sidebar-element{
-    margin-right:50px
-  }
-
   .sidebar-leaf{
-  	font-weight: normal;
-  	display: block;
+    font-weight: normal;
+    display: block;
   }
 
   .sidebar-maincategory{
-  	font-weight: bold;
+    font-weight: bold;
     cursor: pointer;
-
   }
 
-  .sidebar{
-
+  #sidebar{
      text-decoration: none;
      cursor: pointer;
      overflow: hidden;
      margin-right: 0;
      padding-right: 0px;
-     /*width: 100%;*/
-     height: 100%;
-     /*border-right: 2px solid #ddd;*/
   }
 
-  .sidebar h5 {
-    margin-left: 40px;
+  .sidebar-element {
+    display: inline-block;
+    margin: 6px 0 0 0;
+    padding: 0;
+  }
+
+  .sidebar-element .category {
+    display: inline-block;
+    padding: .2em .6em .3em;
+    font-size: 14px;
+    font-weight: bold;
+    line-height: 1;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: 0.35em;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #366036;
+  }
+
+  #sidebar h5 {
+    float: left;
+    clear: left;
+    margin-right: 20px;
   }
 
   @media (max-width: 768px) {
-    .sidebar-element {
-      display: inline-block;
-      padding-left: 10px;
-      margin-right: 0px;
-    }
-
-    .sidebar h5 {
-      margin-left: 0px;
+    #sidebar h5 {
+      float: none;
     }
   }
-%h5 Filter by Design Process
+
+%h5 Filter by Design Process:
 - @search_filter_hash.each do |x|
   %ul.sidebar-element
     .category

--- a/app/views/layouts/wide.html.haml
+++ b/app/views/layouts/wide.html.haml
@@ -29,6 +29,13 @@
         position: relative;
         top: 50px;
       }
+
+      @media (max-width: 768px) {
+        .container {
+          top: 0;
+        }
+      }
+
       .footer{
         position:relative;
         bottom:0%;
@@ -37,9 +44,9 @@
         margin-top:100px;
       }
 
-  
+
     %script{:src => "https://www.google.com/recaptcha/api.js"}
-  
+
   %body
     = render "layouts/headernav"
     .container


### PR DESCRIPTION
Last time I was pretty disappointed with what I had for methods & case studies page:
![image](https://cloud.githubusercontent.com/assets/9982665/24043108/332fa8b6-0ad2-11e7-80a1-d56003aa1f3f.png)
I made some small changes to make it more presentable. 
![image](https://cloud.githubusercontent.com/assets/9982665/24043174/9325a98c-0ad2-11e7-8391-dfabd2152892.png)
I know that this ignores the recent fix to the sidebar. I forgot to pull and so didn't know about it until I merged. I commented James's fix for now, because I wanted to decrease the whitespace to the left so that method descriptions can be larger. This meant condensing the sidebar filter to the top, which you may or may not like. We can discuss that before merging.
Current look: 
![image](https://cloud.githubusercontent.com/assets/9982665/24043215/cdccedf2-0ad2-11e7-8637-24a870d8004d.png)
Compressing the sidebar filter: 
![image](https://cloud.githubusercontent.com/assets/9982665/24043225/db16fca0-0ad2-11e7-864e-65a5127cf293.png)
I also didn't like the look of the edit method page, since the title often sits at the bottom of the page because of the sidebar.
![image](https://cloud.githubusercontent.com/assets/9982665/24043253/0215cc6e-0ad3-11e7-91f6-dc64b5341173.png)
Made some changes. Also prevented images from extending page size beyond the boundaries of a mobile screen.
![image](https://cloud.githubusercontent.com/assets/9982665/24043288/31e35646-0ad3-11e7-939d-e9467a1a3f04.png)
We'll definitely have to discuss these changes before merging this pull request.